### PR TITLE
feat: add tags column with display logic in getItemColumns

### DIFF
--- a/src/app/admin/items/components/columns.tsx
+++ b/src/app/admin/items/components/columns.tsx
@@ -157,6 +157,31 @@ export function getItemColumns(
             },
         },
         {
+            accessorKey: "tags",
+            header: ({ column }) => (
+                <DataTableColumnHeader column={column} title="Tags" />
+            ),
+            cell: ({ row }) => {
+                const tags = row.getValue("tags") as ItemResponse["tags"]
+                return (
+                    <div className="flex flex-wrap gap-1 max-w-[200px]">
+                        {tags.length > 0 ? (
+                            tags.slice(0, 3).map((tag) => (
+                                <Badge key={tag.id} variant="outline">
+                                    {tag.name}
+                                </Badge>
+                            ))
+                        ) : (
+                            <span className="text-muted-foreground text-sm">None</span>
+                        )}
+                        {tags.length > 3 && (
+                            <Badge variant="outline">+{tags.length - 3} more</Badge>
+                        )}
+                    </div>
+                )
+            },
+        },
+        {
             accessorKey: "avg_rating",
             header: ({ column }) => (
                 <DataTableColumnHeader column={column} title="Rating" />


### PR DESCRIPTION
This pull request adds a new column for displaying item tags in the admin items table. The column includes functionality to show up to three tags with a badge for each and indicates if there are additional tags beyond the first three.

### Changes to the admin items table:

* [`src/app/admin/items/components/columns.tsx`](diffhunk://#diff-640e00b2002afd265eb0aac5a0a70d9b3eef4d31c0849bb8bcad8c478d8cf7e9R159-R183): Added a "Tags" column to display item tags. The column shows up to three tags as outlined badges and includes a badge indicating the count of additional tags if there are more than three. If no tags are present, it displays "None" in muted text.